### PR TITLE
Added -help argument for script usage instructions

### DIFF
--- a/PyFuzz.py
+++ b/PyFuzz.py
@@ -1,24 +1,32 @@
 import requests
 from colorama import Fore, Style
+import argparse
 
-print(Fore.GREEN + "~~~~~FUZZER~~~~~" + Style.RESET_ALL)
+def main(url, wordlist_path):
+    print(Fore.GREEN + "~~~~~FUZZER~~~~~" + Style.RESET_ALL)
 
-url = input(Fore.BLUE + "Enter the URL with the placeholder 'FUZZ': " + Style.RESET_ALL)
-wordlist_path = input(Fore.BLUE + "Enter the path of the wordlist file: " + Style.RESET_ALL)
+    with open(wordlist_path, 'r') as f:
+        wordlist = [word.strip() for word in f.readlines()]
 
-with open(wordlist_path, 'r') as f:
-    wordlist = [word.strip() for word in f.readlines()]
+    print(Fore.YELLOW + "\n[-]Starting scan...\n" + Style.RESET_ALL)
+    for word in wordlist:
+        new_url = url.replace("FUZZ", word)
 
-print(Fore.YELLOW + "\n[-]Starting scan...\n" + Style.RESET_ALL)
-for word in wordlist:
-    new_url = url.replace("FUZZ", word)
+        try:
+            response = requests.get(new_url)
+            if response.status_code == 200:
+                print(Fore.GREEN + f"[+]Found: {new_url}" + Style.RESET_ALL)
+            else:
+                #print(Fore.RED + f"[-]Not Found: {new_url}" + Style.RESET_ALL)
+                pass
+        except requests.exceptions.RequestException as e:
+            print(Fore.RED + f"[-]Error: {e}" + Style.RESET_ALL)
 
-    try:
-        response = requests.get(new_url)
-        if response.status_code == 200:
-            print(Fore.GREEN + f"[+]Found: {new_url}" + Style.RESET_ALL)
-        else:
-            #print(Fore.RED + f"[-]Not Found: {new_url}" + Style.RESET_ALL)
-            pass
-    except requests.exceptions.RequestException as e:
-        print(Fore.RED + f"[-]Error: {e}" + Style.RESET_ALL)
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="A simple fuzzer to find resources on a web server.")
+    parser.add_argument('-url', required=True, help="The target URL with the placeholder 'FUZZ'.")
+    parser.add_argument('-wordlist', required=True, help="Path to the wordlist file.")
+    args = parser.parse_args()
+
+    if args.url and args.wordlist:
+        main(args.url, args.wordlist)


### PR DESCRIPTION
Wrapped the main script logic inside a main function for better organization. Used argparse to define and parse command-line arguments.

To run the script, you can now use:
python pyfuzz.py -url "http://example.com/FUZZ/" -wordlist "/path/to/wordlist.txt"

For help, you can use:
python pyfuzz.py -help